### PR TITLE
Smarter way to replace fonts with Arimo, Tinos & Cousine

### DIFF
--- a/31-croscore-elementary.conf
+++ b/31-croscore-elementary.conf
@@ -1,120 +1,76 @@
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
-
     <!-- The serif font should be Tinos -->
-    <match target="pattern">
-        <test qual="any" name="family">
-            <string>serif</string>
-        </test>
-        <edit name="family" mode="assign">
-            <string>Tinos</string>
-        </edit>
-    </match>
-    <match target="pattern">
-        <test qual="any" name="family">
-            <string>Times</string>
-        </test>
-        <edit name="family" mode="assign">
-            <string>Tinos</string>
-        </edit>
-    </match>
-    <match target="pattern">
-        <test qual="any" name="family">
-            <string>Times New Roman</string>
-        </test>
-        <edit name="family" mode="assign">
-            <string>Tinos</string>
-        </edit>
-    </match>
+    <alias>
+        <family>Times</family>
+        <prefer><family>Tinos</family></prefer>
+        <default><family>Tinos</family></default>
+    </alias>
+    <alias>
+        <family>Times New Roman</family>
+        <prefer><family>Tinos</family></prefer>
+        <default><family>Tinos</family></default>
+    </alias>
 
     <!-- The sans-serif font should be Arimo -->
-    <match target="pattern">
-        <test qual="any" name="family">
-            <string>sans-serif</string>
-        </test>
-        <edit name="family" mode="assign">
-            <string>Arimo</string>
-        </edit>
-    </match>
-    <match target="pattern">
-        <test qual="any" name="family">
-            <string>sans</string>
-        </test>
-        <edit name="family" mode="assign">
-            <string>Arimo</string>
-        </edit>
-    </match>
+    <alias>
+        <family>sans</family>
+        <prefer><family>Arimo</family></prefer>
+        <default><family>Arimo</family></default>
+    </alias>
+    <alias>
+        <family>sans-serif</family>
+        <prefer><family>Arimo</family></prefer>
+        <default><family>Arimo</family></default>
+    </alias>
+
     <!-- We need to ensure that layout tests that use "Helvetica" don't
         fall back to the default serif font -->
-    <match target="pattern">
-      <test qual="any" name="family">
-        <string>Helvetica</string>
-      </test>
-      <edit name="family" mode="assign">
-        <string>Arimo</string>
-      </edit>
-    </match>
-    <match target="pattern">
-      <test qual="any" name="family">
-        <string>Arial</string>
-      </test>
-      <edit name="family" mode="assign">
-        <string>Arimo</string>
-      </edit>
-    </match>
-    <match target="pattern">
-      <test qual="any" name="family">
-        <string>Lucida Grande</string>
-      </test>
-      <edit name="family" mode="assign">
-        <string>Arimo</string>
-      </edit>
-    </match>
+    <alias>
+        <family>Helvetica</family>
+        <prefer><family>Arimo</family></prefer>
+        <default><family>Arimo</family></default>
+    </alias>
+    <alias>
+        <family>Arial</family>
+        <prefer><family>Arimo</family></prefer>
+        <default><family>Arimo</family></default>
+    </alias>
+    <alias>
+        <family>Lucida Grande</family>
+        <prefer><family>Arimo</family></prefer>
+        <default><family>Arimo</family></default>
+    </alias>
 
     <!-- The Monospace font should be Cousine -->
-    <match target="pattern">
-        <test qual="any" name="family">
-            <string>monospace</string>
-        </test>
-        <edit name="family" mode="assign">
-            <string>Cousine</string>
-        </edit>
-    </match>
-    <match target="pattern">
-        <test qual="any" name="family">
-            <string>mono</string>
-        </test>
-        <edit name="family" mode="assign">
-            <string>Cousine</string>
-        </edit>
-    </match>
+    <alias>
+        <family>mono</family>
+        <prefer><family>Cousine</family></prefer>
+        <default><family>Cousine</family></default>
+    </alias>
+    <alias>
+        <family>monospace</family>
+        <prefer><family>Cousine</family></prefer>
+        <default><family>Cousine</family></default>
+    </alias>
+
     <!-- We need to ensure that layout tests that use "Courier", "Courier New",
          and "Monaco" (all monospace fonts) don't fall back to the default
          serif font -->
-    <match target="pattern">
-      <test qual="any" name="family">
-        <string>Courier</string>
-      </test>
-      <edit name="family" mode="assign">
-        <string>Cousine</string>
-      </edit>
-    </match>
-    <match target="pattern">
-      <test qual="any" name="family">
-        <string>Courier New</string>
-      </test>
-      <edit name="family" mode="assign">
-        <string>Cousine</string>
-      </edit>
-    </match>
-    <match target="pattern">
-      <test qual="any" name="family">
-        <string>Monaco</string>
-      </test>
-      <edit name="family" mode="assign">
-        <string>Cousine</string>
-      </edit>
-    </match>
-    
+    <alias>
+        <family>Courier</family>
+        <prefer><family>Cousine</family></prefer>
+        <default><family>Cousine</family></default>
+    </alias>
+    <alias>
+        <family>Courier New</family>
+        <prefer><family>Cousine</family></prefer>
+        <default><family>Cousine</family></default>
+    </alias>
+    <alias>
+        <family>Monaco</family>
+        <prefer><family>Cousine</family></prefer>
+        <default><family>Cousine</family></default>
+    </alias>
 </fontconfig>


### PR DESCRIPTION
Uses `<prefer></prefer>` instead of `match -> test -> edit` to ensure the replacement doesn't hit other apps which use other fonts as default, but maintain the default of using these families.