### PR TITLE
meson suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ You'll need the following dependencies:
 Run `meson setup` to configure the build environment
 
 ```bash
-    meson setup build --prefix=/usr
+meson setup build --prefix=/usr
 ```
 
 Change to the build directory and run `ninja install` to install
 
 ```bash
-    cd build
-    ninja install
+cd build
+ninja install
 ```

--- a/debian/fonts-redacted-elementary.install
+++ b/debian/fonts-redacted-elementary.install
@@ -1,1 +1,1 @@
-redacted/*.ttf usr/share/fonts/truetype/redacted-elementary
+usr/share/fonts/truetype/redacted-elementary

--- a/debian/fonts-roboto-mono-elementary.install
+++ b/debian/fonts-roboto-mono-elementary.install
@@ -1,1 +1,1 @@
-roboto-mono/*.ttf usr/share/fonts/truetype/roboto-mono-elementary
+usr/share/fonts/truetype/roboto-mono-elementary

--- a/meson.build
+++ b/meson.build
@@ -12,9 +12,9 @@ install_data(
 )
 
 install_symlink(
-  '31-croscore-elementary.conf',
-  install_dir: get_option('sysconfdir') / 'fonts' / 'conf.d',
-  pointing_to: conf_avail_dir / '31-croscore-elementary.conf'
+    '31-croscore-elementary.conf',
+    install_dir: get_option('sysconfdir') / 'fonts' / 'conf.d',
+    pointing_to: conf_avail_dir / '31-croscore-elementary.conf'
 )
 
 subdir('redacted')

--- a/redacted/meson.build
+++ b/redacted/meson.build
@@ -7,6 +7,6 @@ fonts = [
 foreach font : fonts
     install_data(
         font,
-        install_dir: fonts_dir
+        install_dir: fonts_dir / 'redacted-elementary'
     )
 endforeach

--- a/redacted/meson.build
+++ b/redacted/meson.build
@@ -1,14 +1,12 @@
-install_data(
+fonts = [
     'redacted-script-bold.ttf',
-    install_dir: fonts_dir
-)
-
-install_data(
     'redacted-script-light.ttf',
-    install_dir: fonts_dir
-)
-
-install_data(
     'redacted-script-regular.ttf',
-    install_dir: fonts_dir
-)
+]
+
+foreach font : fonts
+    install_data(
+        font,
+        install_dir: fonts_dir
+    )
+endforeach

--- a/roboto-mono/meson.build
+++ b/roboto-mono/meson.build
@@ -14,6 +14,6 @@ fonts = [
 foreach font : fonts
     install_data(
         font,
-        install_dir: fonts_dir
+        install_dir: fonts_dir / 'roboto-mono-elementary'
     )
 endforeach

--- a/roboto-mono/meson.build
+++ b/roboto-mono/meson.build
@@ -1,49 +1,19 @@
-install_data(
+fonts = [
     'RobotoMono-Bold.ttf',
-    install_dir: fonts_dir
-)
-
-install_data(
     'RobotoMono-BoldItalic.ttf',
-    install_dir: fonts_dir
-)
-
-install_data(
     'RobotoMono-Italic.ttf',
-    install_dir: fonts_dir
-)
-
-install_data(
     'RobotoMono-Light.ttf',
-    install_dir: fonts_dir
-)
-
-install_data(
     'RobotoMono-LightItalic.ttf',
-    install_dir: fonts_dir
-)
-
-install_data(
     'RobotoMono-Medium.ttf',
-    install_dir: fonts_dir
-)
-
-install_data(
     'RobotoMono-MediumItalic.ttf',
-    install_dir: fonts_dir
-)
-
-install_data(
     'RobotoMono-Regular.ttf',
-    install_dir: fonts_dir
-)
-
-install_data(
     'RobotoMono-Thin.ttf',
-    install_dir: fonts_dir
-)
-
-install_data(
     'RobotoMono-ThinItalic.ttf',
-    install_dir: fonts_dir
-)
+]
+
+foreach font : fonts
+    install_data(
+        font,
+        install_dir: fonts_dir
+    )
+endforeach


### PR DESCRIPTION
Suggestion for #24

## Changes Summary
### Suggestions
- DRY install_data()
  - Addresses my comment at https://github.com/elementary/fonts/pull/24#issuecomment-4045858007
- Update .install files
  - Addresses my comment at https://github.com/elementary/fonts/pull/24#issuecomment-4045874345

### Other Related Changes
- Correct install dir
  - Use the install destination path currently as defined in Debian packaging
- Indentation fix
  - meson: Unify to 4 space indentation
  - README: Remove unnecessary indentation

## Checklist
- [x] Building .deb files by `debuild -us -uc` and they contains the same files/directories as before

After:

```
user@elementary-daily:~/work/elementary/fonts (ryonakano/meson-suggestion %)$ dpkg-deb -c ../fonts-roboto-mono-elementary_5.1.0_all.deb
drwxr-xr-x root/root         0 2018-10-16 15:31 ./
drwxr-xr-x root/root         0 2018-10-16 15:31 ./usr/
drwxr-xr-x root/root         0 2018-10-16 15:31 ./usr/share/
drwxr-xr-x root/root         0 2018-10-16 15:31 ./usr/share/doc/
drwxr-xr-x root/root         0 2018-10-16 15:31 ./usr/share/doc/fonts-roboto-mono-elementary/
-rw-r--r-- root/root       278 2018-10-16 15:31 ./usr/share/doc/fonts-roboto-mono-elementary/changelog.gz
-rw-r--r-- root/root       974 2018-10-16 15:31 ./usr/share/doc/fonts-roboto-mono-elementary/copyright
drwxr-xr-x root/root         0 2018-10-16 15:31 ./usr/share/fonts/
drwxr-xr-x root/root         0 2018-10-16 15:31 ./usr/share/fonts/truetype/
drwxr-xr-x root/root         0 2018-10-16 15:31 ./usr/share/fonts/truetype/roboto-mono-elementary/
-rw-r--r-- root/root    113684 2018-10-16 15:31 ./usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Bold.ttf
-rw-r--r-- root/root    121700 2018-10-16 15:31 ./usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-BoldItalic.ttf
-rw-r--r-- root/root    119716 2018-10-16 15:31 ./usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Italic.ttf
-rw-r--r-- root/root    117852 2018-10-16 15:31 ./usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Light.ttf
-rw-r--r-- root/root    126484 2018-10-16 15:31 ./usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-LightItalic.ttf
-rw-r--r-- root/root    113524 2018-10-16 15:31 ./usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Medium.ttf
-rw-r--r-- root/root    122560 2018-10-16 15:31 ./usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-MediumItalic.ttf
-rw-r--r-- root/root    113500 2018-10-16 15:31 ./usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Regular.ttf
-rw-r--r-- root/root    117020 2018-10-16 15:31 ./usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Thin.ttf
-rw-r--r-- root/root    120364 2018-10-16 15:31 ./usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-ThinItalic.ttf
user@elementary-daily:~/work/elementary/fonts (ryonakano/meson-suggestion %)$ dpkg-deb -c ../fonts-redacted-elementary_5.1.0_all.deb
drwxr-xr-x root/root         0 2018-10-16 15:31 ./
drwxr-xr-x root/root         0 2018-10-16 15:31 ./usr/
drwxr-xr-x root/root         0 2018-10-16 15:31 ./usr/share/
drwxr-xr-x root/root         0 2018-10-16 15:31 ./usr/share/doc/
drwxr-xr-x root/root         0 2018-10-16 15:31 ./usr/share/doc/fonts-redacted-elementary/
-rw-r--r-- root/root       278 2018-10-16 15:31 ./usr/share/doc/fonts-redacted-elementary/changelog.gz
-rw-r--r-- root/root       974 2018-10-16 15:31 ./usr/share/doc/fonts-redacted-elementary/copyright
drwxr-xr-x root/root         0 2018-10-16 15:31 ./usr/share/fonts/
drwxr-xr-x root/root         0 2018-10-16 15:31 ./usr/share/fonts/truetype/
drwxr-xr-x root/root         0 2018-10-16 15:31 ./usr/share/fonts/truetype/redacted-elementary/
-rw-r--r-- root/root     19468 2018-10-16 15:31 ./usr/share/fonts/truetype/redacted-elementary/redacted-script-bold.ttf
-rw-r--r-- root/root     19516 2018-10-16 15:31 ./usr/share/fonts/truetype/redacted-elementary/redacted-script-light.ttf
-rw-r--r-- root/root     19368 2018-10-16 15:31 ./usr/share/fonts/truetype/redacted-elementary/redacted-script-regular.ttf
user@elementary-daily:~/work/elementary/fonts (ryonakano/meson-suggestion %)$
```

Before:

```
user@elementary-daily:~/work/elementary/fonts (ryonakano/meson-suggestion %)$ dpkg -L fonts-roboto-mono-elementary
/.
/usr
/usr/share
/usr/share/doc
/usr/share/doc/fonts-roboto-mono-elementary
/usr/share/doc/fonts-roboto-mono-elementary/changelog.Debian.gz
/usr/share/doc/fonts-roboto-mono-elementary/copyright
/usr/share/fonts
/usr/share/fonts/truetype
/usr/share/fonts/truetype/roboto-mono-elementary
/usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Bold.ttf
/usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-BoldItalic.ttf
/usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Italic.ttf
/usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Light.ttf
/usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-LightItalic.ttf
/usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Medium.ttf
/usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-MediumItalic.ttf
/usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Regular.ttf
/usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-Thin.ttf
/usr/share/fonts/truetype/roboto-mono-elementary/RobotoMono-ThinItalic.ttf
user@elementary-daily:~/work/elementary/fonts (ryonakano/meson-suggestion %)$ dpkg -L fonts-redacted-elementary
/.
/usr
/usr/share
/usr/share/doc
/usr/share/doc/fonts-redacted-elementary
/usr/share/doc/fonts-redacted-elementary/changelog.Debian.gz
/usr/share/doc/fonts-redacted-elementary/copyright
/usr/share/fonts
/usr/share/fonts/truetype
/usr/share/fonts/truetype/redacted-elementary
/usr/share/fonts/truetype/redacted-elementary/redacted-script-bold.ttf
/usr/share/fonts/truetype/redacted-elementary/redacted-script-light.ttf
/usr/share/fonts/truetype/redacted-elementary/redacted-script-regular.ttf
user@elementary-daily:~/work/elementary/fonts (ryonakano/meson-suggestion %)$
```