### PR TITLE
control: Add meson to Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,8 @@ Source: elementary-fonts
 Section: fonts
 Priority: optional
 Maintainer: elementary <builds@elementary.io>
-Build-Depends: debhelper (>= 13)
+Build-Depends: debhelper (>= 13),
+               meson
 Standards-Version: 3.9.6
 
 Package: fonts-croscore-config-elementary


### PR DESCRIPTION
Fixes the build failing on Launchpad (I didn't noticed we're missing this in #24 :dizzy_face: )

https://launchpadlibrarian.net/860025193/buildlog_ubuntu-resolute-amd64.elementary-fonts_5.1.0-0+44~daily~ubuntu26.04.1_BUILDING.txt.gz

```
dh_auto_configure: warning: Use of debian/compat is deprecated and will be removed in debhelper (>= 14~).
Can't exec "meson": No such file or directory at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 553.
dh_auto_configure: error: exec (for cmd: meson --version) failed: No such file or directory
dh_auto_configure: error: meson --version returned exit code 255
make: *** [debian/rules:13: binary] Error 255
dpkg-buildpackage: error: debian/rules binary subprocess failed with exit status 2
```

I locally confirmed `dpkg-buildpackage -us -uc` succeeds with this branch.
